### PR TITLE
Add db-migrations to the compose.yaml.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,11 +21,22 @@ services:
         - .env.development
         - .env.production
       healthcheck:
-        test: ["CMD", "pg_isready", "-q", "-d", "tuna_db", "-U", "tuna_db_user"]
+        test: ["CMD", "pg_isready", "-q", "-d", "tuna_db", "-U", "tuna_user"]
         timeout: 30s
         interval: 10s
         retries: 5
       restart: always
+    db-migration:
+      build:
+        context: ./db/migrations
+        dockerfile: Dockerfile
+      env_file:
+        - .env.development
+        - .env.production
+      depends_on:
+        db:
+          condition: service_healthy
+      command: ["npm", "run", "migrate:up"]
     api-gateway:
       build:
         context: ./services/api-gateway

--- a/db/migrations/Dockerfile
+++ b/db/migrations/Dockerfile
@@ -1,0 +1,7 @@
+# Build environment
+FROM node:17-alpine as builder
+WORKDIR /app
+COPY package.json .
+COPY package-lock.json .
+RUN npm ci
+COPY . .


### PR DESCRIPTION
Such that migrations are automatocally ran at `docker compose up`

:exclamation: Checked out from branch https://github.com/Tonfisk-se/tuna-service/tree/johanfant-include-api-gw-in-compose.yaml as to avoid future conflicts, and also does not function properly without somce changes inside https://github.com/Tonfisk-se/tuna-service/pull/27. So do not merge this to `dev` before those.